### PR TITLE
Fix crashes during Activity onPause()

### DIFF
--- a/android/lib/src/main/java/com/airbnb/android/react/maps/AirMapManager.java
+++ b/android/lib/src/main/java/com/airbnb/android/react/maps/AirMapManager.java
@@ -65,12 +65,6 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
         return new AirMapView(context, this.appContext, this);
     }
 
-    @Override
-    public void onDropViewInstance(AirMapView view) {
-        view.doDestroy();
-        super.onDropViewInstance(view);
-    }
-
     private void emitMapError(String message, String type) {
         WritableMap error = Arguments.createMap();
         error.putString("message", message);

--- a/android/lib/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/android/lib/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -272,6 +272,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     }
 
     public void setRegion(ReadableMap region) {
+        if (!checkReady()) return;
         if (region == null) return;
 
         Double lng = region.getDouble("longitude");
@@ -460,16 +461,20 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     }
 
     public void animateToRegion(LatLngBounds bounds, int duration) {
+        if (!checkReady()) return;
         startMonitoringRegion();
         map.animateCamera(CameraUpdateFactory.newLatLngBounds(bounds, 0), duration, null);
     }
 
     public void animateToCoordinate(LatLng coordinate, int duration) {
+        if (!checkReady()) return;
         startMonitoringRegion();
         map.animateCamera(CameraUpdateFactory.newLatLng(coordinate), duration, null);
     }
 
     public void fitToElements(boolean animated) {
+        if (!checkReady()) return;
+
         LatLngBounds.Builder builder = new LatLngBounds.Builder();
         for (AirMapFeature feature : features) {
             if (feature instanceof AirMapMarker) {
@@ -679,5 +684,13 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
         LatLng coords = this.map.getProjection().fromScreenLocation(point);
         WritableMap event = makeClickEventData(coords);
         manager.pushEvent(this, "onPanDrag", event);
+    }
+
+    /**
+     * Checks if the map is ready (which depends on whether the Google Play services APK is
+     * available. This should be called prior to calling any methods on GoogleMap.
+     */
+    private boolean checkReady() {
+        return map != null;
     }
 }

--- a/android/lib/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/android/lib/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -135,7 +135,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
         onLayoutChangeListener = new OnLayoutChangeListener() {
             @Override public void onLayoutChange(View v, int left, int top, int right, int bottom,
                 int oldLeft, int oldTop, int oldRight, int oldBottom) {
-                if (!AirMapView.this.paused) {
+                if (!paused) {
                     AirMapView.this.cacheView();
                 }
             }
@@ -236,7 +236,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
         // updating location constantly, killing the battery, even though some other location-mgmt
         // module may
         // desire to shut-down location-services.
-        lifecycleListener = new LifecycleEventListener() {
+        LifecycleEventListener lifecycleListener = new LifecycleEventListener() {
             @Override
             public void onHostResume() {
                 if (hasPermissions()) {
@@ -255,15 +255,11 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
                     //noinspection MissingPermission
                     map.setMyLocationEnabled(false);
                 }
-                synchronized (AirMapView.this) {
-                    AirMapView.this.onPause();
-                    paused = true;
-                }
+                paused = true;
             }
 
             @Override
             public void onHostDestroy() {
-                AirMapView.this.doDestroy();
             }
         };
 
@@ -273,20 +269,6 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     private boolean hasPermissions() {
         return checkSelfPermission(getContext(), PERMISSIONS[0]) == PackageManager.PERMISSION_GRANTED ||
                 checkSelfPermission(getContext(), PERMISSIONS[1]) == PackageManager.PERMISSION_GRANTED;
-    }
-
-    /*
-    onDestroy is final method so I can't override it.
-     */
-    public synchronized void doDestroy() {
-        if (lifecycleListener != null) {
-            context.removeLifecycleEventListener(lifecycleListener);
-            lifecycleListener = null;
-        }
-        if (!paused) {
-            onPause();
-        }
-        onDestroy();
     }
 
     public void setRegion(ReadableMap region) {


### PR DESCRIPTION
This is a fix cherry-picked from
https://github.com/airbnb/react-native-maps/pull/694

It resolves a NullPointerError occurring when application is closed
using the back button on Android.